### PR TITLE
eat(hero): extract CTA label component and add gradient badge styling

### DIFF
--- a/xtreme_fitness_materials/src/components/Button/CtaLabel.jsx
+++ b/xtreme_fitness_materials/src/components/Button/CtaLabel.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { MdPlayArrow } from "react-icons/md";
+
+const CtaLabel = () => {
+  return (
+    <span className="flex items-center justify-center gap-4 md:gap-6">
+      Tilmeld dig nu
+      <span
+        className="inline-flex h-7.75 w-10.5 md:h-12 md:w-16 items-center justify-center rounded-full"
+        style={{ background: "var(--gradient-price-badge)" }}
+      >
+        <MdPlayArrow className="text-white text-3xl md:text-5xl" />
+      </span>
+    </span>
+  );
+};
+
+export default CtaLabel;

--- a/xtreme_fitness_materials/src/components/Button/PrimaryButton.jsx
+++ b/xtreme_fitness_materials/src/components/Button/PrimaryButton.jsx
@@ -9,9 +9,9 @@ const PrimaryButton = ({ children, to, ...rest }) => {
         to={to}
         {...rest}
         className={clsx(
-          "border-2 border-white bg-transparent py-8 px-32 rounded w-full cursor-pointer mt-14",
-          "font-zen font-normal text-secondary text-5xl",
-          "rounded-br-[3.125rem] rounded-tl-[3.125rem]",
+          "border-2 border-btn-border bg-transparent py-4 px-10 rounded w-full text-center cursor-pointer mt-12 md:mt-14",
+          "font-zen font-medium text-secondary text-base md:text-2xl",
+          "rounded-[6.25rem]",
           "transition duration-300 ease-in-out",
           "hover:bg-white/20 hover:backdrop-blur-md hover:border-white/50",
         )}

--- a/xtreme_fitness_materials/src/components/Hero/Hero.jsx
+++ b/xtreme_fitness_materials/src/components/Hero/Hero.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Button from "../Button/PrimaryButton";
+import CtaLabel from "../Button/CtaLabel";
 import heroBg from "../../assets/Header/mainHeader.jpg";
 
 // button mt-5
@@ -7,13 +8,14 @@ const heroText = [
   {
     id: 1,
     subject: "xtreme fitness",
-    title: "Bliv stærkr",
+    title: "Bliv stærk",
     desc: "Det bedste fitnesscenter — hvor styrke og sundhed vokser sammen.",
     subjectClass:
-      "font-normal font-teko text-secondary text-2xl tracking-[7.5px] uppercase mb-2",
+      "font-normal font-teko text-secondary text-2xl md:text-4xl tracking-[7.5px] md:tracking-[8.5px] uppercase mb-2 md:mb-4",
     titleClass:
-      "font-bold font-teko text-primary text-3xl tracking-[1.2px] uppercase",
-    descClass: "font-normal text-secondary text-xs text-center max-w-[260px]",
+      "font-bold font-teko text-primary text-3xl md:text-6xl tracking-[1.2px] md:tracking-[1.4px] uppercase",
+    descClass:
+      "font-normal text-secondary text-xs md:text-xl text-center max-w-[260px] md:max-w-[360px]",
   },
 ];
 
@@ -32,7 +34,9 @@ const Hero = () => {
       <div className="absolute inset-0 flex items-center justify-center">
         <div className="flex flex-col items-center justify-center">
           <HeroItem />
-          <Button to="#">Tilmeld dig nu</Button>
+          <Button to="#">
+            <CtaLabel />
+          </Button>
         </div>
       </div>
     </section>

--- a/xtreme_fitness_materials/src/index.css
+++ b/xtreme_fitness_materials/src/index.css
@@ -8,7 +8,7 @@
   --color-footer: #000;
 
   --color-hero-overlay: rgba(0, 0, 0, 0.30);
-  
+
   --color-primary: #fff;
   --color-secondary: #fff;
 
@@ -16,7 +16,11 @@
   --color-dark-secondary: #000000;
   --color-text-slogan: #E54E41;
 
-  --color-price-badge: rgba(229, 78, 65, 1);
+  --color-btn-badge: rgba(229, 78, 65, 1);
+  --color-btn-border: rgba(235, 235, 235, 0.5);
+
+  /* --color-price-badge-hot: rgba(255, 170, 0, 1); */
+  --gradient-price-badge: linear-gradient(160deg, #e54e41 0%, #ff8a00 60%);
 
   /* employees-section */
   --color-employees-section: rgba(229, 78, 65, 1);


### PR DESCRIPTION
- Improve Hero CTA by separating label/icon UI into a reusable component and refining button behavior.
- Add CtaLabel component for CTA text + play icon badge.
- Update Hero to use the extracted CTA component.
- Refine PrimaryButton interaction/structure classes.
- Add and tune theme tokens in index.css for price badge gradient.