### PR TITLE
Add production Vercel domain to CORS whitelist.

### DIFF
--- a/mcd_web_xtremefitness_server/lib/server.js
+++ b/mcd_web_xtremefitness_server/lib/server.js
@@ -35,7 +35,16 @@ const expressServer = express();
 // middleware
 expressServer.use(bodyParser.json());
 expressServer.use(bodyParser.urlencoded({ extended: true }));
-expressServer.use(cors());
+expressServer.use(
+  cors({
+    origin: [
+      "https://xtreme-fitness-fagproeve-git-main-sleiterrs-projects.vercel.app",
+      "https://xtreme-fitness-fagproeve.vercel.app",
+      "http://localhost:5173",
+    ],
+    credentials: true,
+  }),
+);
 expressServer.use(cookieParser());
 
 // Serve static files from the public and www directories.


### PR DESCRIPTION
- Updated CORS middleware to allow requests from both preview and production Vercel domains.
- Ensures frontend works without CORS errors in all environments.